### PR TITLE
Update Java compatibility configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,13 @@ group = "net.thenextlvl.services"
 version = "0.1.0"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
     withSourcesJar()
     withJavadocJar()
+}
+
+tasks.compileJava {
+    options.release.set(21)
 }
 
 repositories {


### PR DESCRIPTION
Replaced deprecated `sourceCompatibility` and `targetCompatibility` with the `java.toolchain.languageVersion` property. Added the `options.release` setting in `compileJava` task for better clarity and compatibility.