### PR TITLE
Refactor PluginVersionChecker and update dependency versions

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     compileOnly("net.luckperms:api:5.4")
 
     implementation("com.github.MilkBowl:VaultAPI:1.7.1")
-    implementation("net.thenextlvl.core:paper:1.4.1")
+    implementation("net.thenextlvl.core:paper:1.5.1")
     implementation("org.bstats:bstats-bukkit:3.0.3")
 
     implementation(rootProject)

--- a/plugin/src/main/java/net/thenextlvl/service/version/PluginVersionChecker.java
+++ b/plugin/src/main/java/net/thenextlvl/service/version/PluginVersionChecker.java
@@ -2,40 +2,16 @@ package net.thenextlvl.service.version;
 
 import core.paper.version.PaperHangarVersionChecker;
 import core.version.SemanticVersion;
-import lombok.Getter;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
-
-@Getter
-@SuppressWarnings("UnstableApiUsage")
 public class PluginVersionChecker extends PaperHangarVersionChecker<SemanticVersion> {
-    private final SemanticVersion versionRunning;
-    private final Plugin plugin;
-
     public PluginVersionChecker(Plugin plugin) {
-        super("ServiceIO");
-        this.plugin = plugin;
-        this.versionRunning = Objects.requireNonNull(parseVersion(plugin.getPluginMeta().getVersion()));
+        super(plugin, "TheNextLvl", "ServiceIO");
     }
 
     @Override
     public @Nullable SemanticVersion parseVersion(String version) {
         return SemanticVersion.parse(version);
-    }
-
-    public void checkVersion() {
-        retrieveLatestSupportedVersion(latest -> latest.ifPresentOrElse(version -> {
-            if (version.equals(getVersionRunning())) {
-                plugin.getComponentLogger().info("You are running the latest version of ServiceIO");
-            } else if (version.compareTo(getVersionRunning()) > 0) {
-                plugin.getComponentLogger().warn("An update for ServiceIO is available");
-                plugin.getComponentLogger().warn("You are running version {}, the latest supported version is {}", getVersionRunning(), version);
-                plugin.getComponentLogger().warn("Update at https://hangar.papermc.io/TheNextLvl/ServiceIO");
-            } else {
-                plugin.getComponentLogger().warn("You are running a snapshot version of ServiceIO");
-            }
-        }, () -> plugin.getComponentLogger().error("Version check failed")));
     }
 }


### PR DESCRIPTION
Refactored `PluginVersionChecker` by consolidating constructors and removing redundant fields. Updated `net.thenextlvl.core:paper` dependency from version 1.4.1 to 1.5.1 in `build.gradle.kts`.