### PR TITLE
Remove optional banks from economy interface

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/service/ServicePlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/service/ServicePlugin.java
@@ -23,6 +23,7 @@ import net.thenextlvl.service.version.PluginVersionChecker;
 import net.thenextlvl.service.wrapper.VaultChatServiceWrapper;
 import net.thenextlvl.service.wrapper.VaultEconomyServiceWrapper;
 import net.thenextlvl.service.wrapper.VaultPermissionServiceWrapper;
+import net.thenextlvl.service.wrapper.service.BankServiceWrapper;
 import net.thenextlvl.service.wrapper.service.ChatServiceWrapper;
 import net.thenextlvl.service.wrapper.service.EconomyServiceWrapper;
 import net.thenextlvl.service.wrapper.service.PermissionServiceWrapper;
@@ -157,8 +158,10 @@ public class ServicePlugin extends JavaPlugin {
         services.getRegistrations(Economy.class).forEach(economy -> {
             var wrapper = new EconomyServiceWrapper(economy.getProvider(), this);
             services.register(EconomyController.class, wrapper, economy.getPlugin(), economy.getPriority());
-            wrapper.getBankController().ifPresent(controller ->
-                    services.register(BankController.class, controller, economy.getPlugin(), economy.getPriority()));
+            if (economy.getProvider().hasBankSupport()) {
+                var banks = new BankServiceWrapper(economy.getProvider(), this);
+                services.register(BankController.class, banks, economy.getPlugin(), economy.getPriority());
+            }
         });
     }
 

--- a/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultEconomyServiceWrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultEconomyServiceWrapper.java
@@ -2,7 +2,6 @@ package net.thenextlvl.service.wrapper;
 
 import core.annotation.FieldsAreNotNullByDefault;
 import core.annotation.ParametersAreNullableByDefault;
-import lombok.RequiredArgsConstructor;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.thenextlvl.service.api.economy.Account;
@@ -12,6 +11,7 @@ import net.thenextlvl.service.api.economy.bank.BankController;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Locale;
@@ -21,12 +21,18 @@ import java.util.concurrent.ExecutionException;
 import static net.milkbowl.vault.economy.EconomyResponse.ResponseType.FAILURE;
 import static net.milkbowl.vault.economy.EconomyResponse.ResponseType.SUCCESS;
 
-@RequiredArgsConstructor
 @FieldsAreNotNullByDefault
 @ParametersAreNullableByDefault
 public class VaultEconomyServiceWrapper implements Economy {
+    private final @Nullable BankController bankController;
     private final EconomyController economyController;
     private final Plugin plugin;
+
+    public VaultEconomyServiceWrapper(@NotNull EconomyController economyController, @NotNull Plugin plugin) {
+        this.bankController = plugin.getServer().getServicesManager().load(BankController.class);
+        this.economyController = economyController;
+        this.plugin = plugin;
+    }
 
     @Override
     public boolean isEnabled() {
@@ -39,13 +45,13 @@ public class VaultEconomyServiceWrapper implements Economy {
     }
 
     private BankController bankController() throws UnsupportedOperationException {
-        return economyController.getBankController().orElseThrow(() ->
-                new UnsupportedOperationException(getName() + " has no bank support"));
+        if (bankController != null) return bankController;
+        throw new UnsupportedOperationException(getName() + " has no bank support");
     }
 
     @Override
     public boolean hasBankSupport() {
-        return economyController.getBankController().isPresent();
+        return bankController != null;
     }
 
     @Override

--- a/plugin/src/main/java/net/thenextlvl/service/wrapper/service/EconomyServiceWrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/wrapper/service/EconomyServiceWrapper.java
@@ -4,11 +4,9 @@ import net.milkbowl.vault.economy.Economy;
 import net.thenextlvl.service.ServicePlugin;
 import net.thenextlvl.service.api.economy.Account;
 import net.thenextlvl.service.api.economy.EconomyController;
-import net.thenextlvl.service.api.economy.bank.BankController;
 import net.thenextlvl.service.wrapper.service.model.WrappedAccount;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -16,19 +14,12 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class EconomyServiceWrapper implements EconomyController {
-    private final @Nullable BankController bankController;
     private final Economy economy;
     private final ServicePlugin plugin;
 
     public EconomyServiceWrapper(Economy economy, ServicePlugin plugin) {
-        this.bankController = economy.hasBankSupport() ? new BankServiceWrapper(economy, plugin) : null;
         this.economy = economy;
         this.plugin = plugin;
-    }
-
-    @Override
-    public Optional<BankController> getBankController() {
-        return Optional.ofNullable(bankController);
     }
 
     @Override

--- a/src/main/java/net/thenextlvl/service/api/economy/EconomyController.java
+++ b/src/main/java/net/thenextlvl/service/api/economy/EconomyController.java
@@ -1,6 +1,5 @@
 package net.thenextlvl.service.api.economy;
 
-import net.thenextlvl.service.api.economy.bank.BankController;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.jetbrains.annotations.Contract;
@@ -14,13 +13,6 @@ import java.util.concurrent.CompletableFuture;
  * The AccountController interface provides methods to create, retrieve and delete accounts.
  */
 public interface EconomyController {
-    /**
-     * Retrieves the BankController associated with this EconomyController.
-     *
-     * @return an optional containing the BankController, or empty if no bank support
-     */
-    Optional<BankController> getBankController();
-
     /**
      * Formats the specified amount as a string.
      *


### PR DESCRIPTION
This PR removes the bankController getter from the economy controller in order to simplify implementations