### PR TITLE
Fixes vault permission wrappers

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
@@ -79,10 +79,9 @@ public class VaultPermissionServiceWrapper extends Permission {
         var groupController = groupController();
         return Optional.ofNullable(world)
                 .map(plugin.getServer()::getWorld)
-                .map(target -> groupController.createGroup(group, target))
-                .orElseGet(() -> groupController.createGroup(group))
-                .thenApply(created -> true)
-                .join();
+                .flatMap(target -> groupController.getGroup(groupName, target))
+                .map(group -> group.addPermission(permission))
+                .orElse(false);
     }
 
     @Override

--- a/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
@@ -64,8 +64,11 @@ public class VaultPermissionServiceWrapper extends Permission {
     }
 
     @Override
-        return groupController().getGroup(groupName)
     public boolean groupHas(String world, String groupName, String permission) {
+        var groupController = groupController();
+        return Optional.ofNullable(world)
+                .map(plugin.getServer()::getWorld)
+                .flatMap(target -> groupController.getGroup(groupName, target))
                 .map(group -> group.checkPermission(permission))
                 .map(TriState.TRUE::equals)
                 .orElse(false);

--- a/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
@@ -68,7 +68,8 @@ public class VaultPermissionServiceWrapper extends Permission {
         var groupController = groupController();
         return Optional.ofNullable(world)
                 .map(plugin.getServer()::getWorld)
-                .flatMap(target -> groupController.getGroup(groupName, target))
+                .flatMap(target -> groupController.getGroup(groupName, target)
+                        .or(() -> groupController.getGroup(groupName)))
                 .map(group -> group.checkPermission(permission))
                 .map(TriState.TRUE::equals)
                 .orElse(false);
@@ -79,7 +80,8 @@ public class VaultPermissionServiceWrapper extends Permission {
         var groupController = groupController();
         return Optional.ofNullable(world)
                 .map(plugin.getServer()::getWorld)
-                .flatMap(target -> groupController.getGroup(groupName, target))
+                .flatMap(target -> groupController.getGroup(groupName, target)
+                        .or(() -> groupController.getGroup(groupName)))
                 .map(group -> group.addPermission(permission))
                 .orElse(false);
     }
@@ -89,7 +91,8 @@ public class VaultPermissionServiceWrapper extends Permission {
         var groupController = groupController();
         return Optional.ofNullable(world)
                 .map(plugin.getServer()::getWorld)
-                .flatMap(target -> groupController.getGroup(groupName, target))
+                .flatMap(target -> groupController.getGroup(groupName, target)
+                        .or(() -> groupController.getGroup(groupName)))
                 .map(group -> group.removePermission(permission))
                 .orElse(false);
     }

--- a/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/wrapper/VaultPermissionServiceWrapper.java
@@ -89,9 +89,9 @@ public class VaultPermissionServiceWrapper extends Permission {
         var groupController = groupController();
         return Optional.ofNullable(world)
                 .map(plugin.getServer()::getWorld)
-                .map(target -> groupController.deleteGroup(group, target))
-                .orElseGet(() -> groupController.deleteGroup(group))
-                .join();
+                .flatMap(target -> groupController.getGroup(groupName, target))
+                .map(group -> group.removePermission(permission))
+                .orElse(false);
     }
 
     @Override


### PR DESCRIPTION
1. Fixed vault permission wrapper deleting group instead of removing permission
2. Fixed vault permission wrapper creating group instead of assigning permission
3. Fixed world being ignored in group permission check
4. Improve fallback logic for undefined worlds