### PR TITLE
Added experimental compatibility mode

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -65,6 +65,7 @@ tasks.test {
 paper {
     name = "ServiceIO"
     main = "net.thenextlvl.service.ServicePlugin"
+    bootstrapper = "net.thenextlvl.service.ServiceBootstrapper"
     author = "NonSwag"
     apiVersion = "1.21"
     foliaSupported = true

--- a/plugin/src/main/java/net/thenextlvl/service/ServiceBootstrapper.java
+++ b/plugin/src/main/java/net/thenextlvl/service/ServiceBootstrapper.java
@@ -1,0 +1,44 @@
+package net.thenextlvl.service;
+
+import io.papermc.paper.plugin.bootstrap.BootstrapContext;
+import io.papermc.paper.plugin.bootstrap.PluginBootstrap;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NullMarked
+public class ServiceBootstrapper implements PluginBootstrap {
+    public static final String ISSUES = "https://github.com/TheNextLvl-net/service-io/issues/new?template=bug_report.yml";
+    public static final boolean COMPATIBILITY_MODE = Boolean.parseBoolean(System.getenv("COMPATIBILITY_MODE"));
+
+    @Override
+    public void bootstrap(BootstrapContext context) {
+        if (COMPATIBILITY_MODE) enableCompatibilityMode(context);
+    }
+
+    private void enableCompatibilityMode(BootstrapContext context) {
+        var logger = context.getLogger();
+        try {
+            var meta = context.getConfiguration();
+
+            var metaClass = meta.getClass();
+            var name = metaClass.getDeclaredField("name");
+            var provides = metaClass.getDeclaredField("provides");
+
+            name.trySetAccessible();
+            provides.trySetAccessible();
+
+            var providedPlugins = new ArrayList<>(meta.getProvidedPlugins());
+            providedPlugins.remove("Vault");
+            providedPlugins.add(meta.getName());
+
+            name.set(meta, "Vault");
+            provides.set(meta, List.copyOf(providedPlugins));
+            logger.info("Enabled compatibility mode, only use this if you really need to.");
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            logger.warn("Failed to initialize compatibility mode", e);
+            logger.warn("Please look for similar issues or report this on GitHub: {}", ISSUES);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #63 

The compatibility mode internally renames `ServiceIO` to `Vault` on bootstrap.
This can help with some plugins that iterate over the plugin list and check for the existence of Vault via `Plugin#getName` or `PluginMeta#getName` instead of using `PluginManager#getPlugin` or `PluginManager#isPluginEnabled`.

Compatibility mode can be enabled by setting the environment variable `COMPATIBILITY_MODE` to `true`

> `COMPATIBILITY_MODE=true`

>[!IMPORTANT]
> If a plugin doesn’t work without compatibility mode, please [report it](https://github.com/TheNextLvl-net/service-io/issues/new?template=incompatible_plugin.yml), **even** if it works with it enabled.