### PR TITLE
Moved maven publication to `net.thenextlvl:service-io`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
 publishing {
     publications.create<MavenPublication>("maven") {
+        artifactId = "service-io"
+        groupId = "net.thenextlvl"
         pom.url.set("https://thenextlvl.net/docs/serviceio")
         pom.scm {
             val repository = "TheNextLvl-net/service-io"


### PR DESCRIPTION
Moved maven publication from `net.thenextlvl.services:service-io` to `net.thenextlvl:service-io`